### PR TITLE
odstraneny TED z referencii

### DIFF
--- a/source/index.twig
+++ b/source/index.twig
@@ -143,8 +143,7 @@ layout: default
             <div class="col-md-12">
                 <p>
                     Určitě znáš <a href="https://speakerdeck.com/odolbeau/symfony-at-blablacar">BlaBlaCar</a>,
-                    <a href="https://www.youtube.com/watch?v=CFQaVDR96x4">Spotify</a>,
-                    <a href="http://hello.ted.com/2013/10/04/under-the-hood/">TED</a>
+                    <a href="https://www.youtube.com/watch?v=CFQaVDR96x4">Spotify</a>
                     nebo
                     <a href="https://www.youtube.com/watch?v=RlkCdM_f3p4">YouPorn</a>.
                     <br>


### PR DESCRIPTION
v linkovanom odkaze bolo napisane ze TED pouzival staru verziu symfony 1.2 a namiesto migracie na 2.0 sa rozhodli preist na ROR, co nieje zrovna najlepsi selling point pre symfony